### PR TITLE
Split to make ambertools agnostic base package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About openff-fragmenter-recipe
-==============================
+About openff-fragmenter-split
+=============================
 
 Home: https://github.com/openforcefield/openff-fragmenter
 
@@ -37,10 +37,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-openff--fragmenter-green.svg)](https://anaconda.org/conda-forge/openff-fragmenter) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/openff-fragmenter.svg)](https://anaconda.org/conda-forge/openff-fragmenter) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/openff-fragmenter.svg)](https://anaconda.org/conda-forge/openff-fragmenter) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/openff-fragmenter.svg)](https://anaconda.org/conda-forge/openff-fragmenter) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-openff--fragmenter--base-green.svg)](https://anaconda.org/conda-forge/openff-fragmenter-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/openff-fragmenter-base.svg)](https://anaconda.org/conda-forge/openff-fragmenter-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/openff-fragmenter-base.svg)](https://anaconda.org/conda-forge/openff-fragmenter-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/openff-fragmenter-base.svg)](https://anaconda.org/conda-forge/openff-fragmenter-base) |
 
-Installing openff-fragmenter-recipe
-===================================
+Installing openff-fragmenter-split
+==================================
 
-Installing `openff-fragmenter-recipe` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `openff-fragmenter-split` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -98,17 +98,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating openff-fragmenter-recipe-feedstock
-===========================================
+Updating openff-fragmenter-split-feedstock
+==========================================
 
-If you would like to improve the openff-fragmenter-recipe recipe or build a new
+If you would like to improve the openff-fragmenter-split recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/openff-fragmenter-recipe-feedstock are
+Note that all branches in the conda-forge/openff-fragmenter-split-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About openff-fragmenter
-=======================
+About openff-fragmenter-recipe
+==============================
 
 Home: https://github.com/openforcefield/openff-fragmenter
 
@@ -35,21 +35,22 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-openff--fragmenter-green.svg)](https://anaconda.org/conda-forge/openff-fragmenter) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/openff-fragmenter.svg)](https://anaconda.org/conda-forge/openff-fragmenter) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/openff-fragmenter.svg)](https://anaconda.org/conda-forge/openff-fragmenter) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/openff-fragmenter.svg)](https://anaconda.org/conda-forge/openff-fragmenter) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-openff--fragmenter--base-green.svg)](https://anaconda.org/conda-forge/openff-fragmenter-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/openff-fragmenter-base.svg)](https://anaconda.org/conda-forge/openff-fragmenter-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/openff-fragmenter-base.svg)](https://anaconda.org/conda-forge/openff-fragmenter-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/openff-fragmenter-base.svg)](https://anaconda.org/conda-forge/openff-fragmenter-base) |
 
-Installing openff-fragmenter
-============================
+Installing openff-fragmenter-recipe
+===================================
 
-Installing `openff-fragmenter` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `openff-fragmenter-recipe` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `openff-fragmenter` can be installed with:
+Once the `conda-forge` channel has been enabled, `openff-fragmenter, openff-fragmenter-base` can be installed with:
 
 ```
-conda install openff-fragmenter
+conda install openff-fragmenter openff-fragmenter-base
 ```
 
 It is possible to list all of the versions of `openff-fragmenter` available on your platform with:
@@ -97,17 +98,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating openff-fragmenter-feedstock
-====================================
+Updating openff-fragmenter-recipe-feedstock
+===========================================
 
-If you would like to improve the openff-fragmenter recipe or build a new
+If you would like to improve the openff-fragmenter-recipe recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/openff-fragmenter-feedstock are
+Note that all branches in the conda-forge/openff-fragmenter-recipe-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,0 +1,1 @@
+${PYTHON} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.1.0" %}
 
 package:
-  name: {{ name|lower }}-recipe
+  name: {{ name|lower }}-split
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.1.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name|lower }}-recipe
   version: {{ version }}
 
 source:
@@ -10,28 +10,47 @@ source:
   sha256: 685256e0885ef23df7c4e8aa601a768fcb54867712671cf7d210d7f5284be7be
 
 build:
-  number: 0
-  noarch: python
-  script: "{{ PYTHON }} -m pip install . -vv"
+  number: 1
 
-requirements:
-  host:
-    - python >=3.6
-    - pip
-  run:
-    - python >=3.6
-    - openff-toolkit-base >=0.9.2
-    - numpy
-    - pydantic
-    - networkx
-    - jinja2
-    - typing-extensions
-    - rdkit
-    - ambertools
+outputs:
+  - name: {{ name|lower }}-base
+    script: build_base.sh
+    build:
+      noarch: python
 
-test:
-  imports:
-    - openff.fragmenter
+    requirements:
+      host:
+        - python >=3.6
+        - pip
+      run:
+        - python >=3.6
+        - openff-toolkit-base >=0.9.2
+        - numpy
+        - pydantic
+        - networkx
+        - jinja2
+        - typing-extensions
+
+    test:
+      imports:
+        - openff.fragmenter
+
+  - name: {{ name|lower }}
+    build:
+      noarch: python
+
+    requirements:
+      host:
+        - python >=3.6
+      run:
+        - python >=3.6
+        - rdkit
+        - ambertools
+        - {{ pin_subpackage('openff-fragmenter-base', exact=True) }}
+
+    test:
+      imports:
+        - openff.fragmenter
 
 about:
   home: https://github.com/openforcefield/openff-fragmenter


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR splits the package into `openff-fragmenter-base` and `openff-fragmenter` whereby the base package does not depend on `AmberTools` while the full package does. The base package is require to install certain fortran packages from other channels (e.g. psi4) that conflict with ambertools
